### PR TITLE
Add general sponsoring info + some minor cleanup

### DIFF
--- a/static/2014.html
+++ b/static/2014.html
@@ -5,15 +5,11 @@
             <dd>26. bis 28. März 2014</dd>
           <dt>Veranstaltungsort</dt>
             <dd>Kulturzentrum FAUST ("Warenannahme") in Hannover</dd>
-          <dt>Act!</dt>
-            <dd><a href="http://act.yapc.eu/gpw2014">Act! 2014</a></dd>
+          <dt>Informationen über die Veranstaltung</dt>
+            <dd><a href="http://act.yapc.eu/gpw2014">16. Deutscher Perl-Workshop 2014 in Hannover</a></dd>
         </dl>
-        <p>
-            Kurze Beschreibung Workshop 2014
-        </p>
-
-<big><strong>Videos</strong></big><br />
-<iframe width="500" height="315" src="https://www.youtube.com/embed/videoseries?list=PLiKOSMurci-jUdnXdTGCWHzONJitWpb0z" frameborder="0" allowfullscreen></iframe>
+        <h4>Videos</h4>
+        <iframe width="500" height="315" src="https://www.youtube.com/embed/videoseries?list=PLiKOSMurci-jUdnXdTGCWHzONJitWpb0z" frameborder="0" allowfullscreen></iframe>
 
       </section>
 

--- a/static/2015.html
+++ b/static/2015.html
@@ -5,14 +5,11 @@
             <dd>06. bis 08. Mai 2015</dd>
           <dt>Veranstaltungsort</dt>
             <dd>Dresdner Volkshaus</dd>
-          <dt>Act!</dt>
-            <dd><a href="http://act.yapc.eu/gpw2015">Act! 2015</a></dd>
+          <dt>Information über die Veranstaltung</dt>
+            <dd><a href="http://act.yapc.eu/gpw2015">17. Deutscher Perl-Workshop 2015 in Dresden</a></dd>
         </dl>
-        <p>
-            Kurze Beschreibung Workshop 2015
-        </p>
-<big><strong>Videos</strong></big><br />
-<iframe width="500" height="315" src="https://www.youtube.com/embed/videoseries?list=UUQtW0UtwR2g1KpC22hSlScg" frameborder="0" allowfullscreen></iframe>
+        <h4>Videos</h4>
+        <iframe width="500" height="315" src="https://www.youtube.com/embed/videoseries?list=UUQtW0UtwR2g1KpC22hSlScg" frameborder="0" allowfullscreen></iframe>
 
 
       </section>

--- a/static/2016.html
+++ b/static/2016.html
@@ -5,15 +5,12 @@
             <dd>09. bis 11. März 2016</dd>
           <dt>Veranstaltungsort</dt>
             <dd>DATEV IT-Campus in Nürnberg</dd>
-          <dt>Act!</dt>
-            <dd><a href="http://act.yapc.eu/gpw2016">Act! 2016</a></dd>
+          <dt>Information über die Veranstaltung</dt>
+            <dd><a href="http://act.yapc.eu/gpw2016">18. Deutscher Perl-Workshop 2016 in Nürnberg</a></dd>
         </dl>
-        <p>
-            Kurze Beschreibung Workshop 2016
-        </p>
-<big><strong>Videos</strong></big><br />
-<iframe width="500" height="315" src="https://www.youtube.com/embed/videoseries?list=PLaDtghjWTaH3PClk6HXrTPE1ty7G-Xvf-" frameborder="0" allowfullscreen></iframe>
 
+        <h4>Videos</h4>
+        <iframe width="500" height="315" src="https://www.youtube.com/embed/videoseries?list=PLaDtghjWTaH3PClk6HXrTPE1ty7G-Xvf-" frameborder="0" allowfullscreen></iframe>
 
       </section>
 

--- a/static/2017.html
+++ b/static/2017.html
@@ -5,12 +5,9 @@
             <dd>26. bis 28. Juni 2017</dd>
           <dt>Veranstaltungsort</dt>
             <dd>Bürgerhaus Wilhelmsburg, Hamburg</dd>
-          <dt>Act!</dt>
-            <dd><a href="http://act.yapc.eu/gpw2017">Act! 2017</a></dd>
+          <dt>Information über die Veranstaltung</dt>
+            <dd><a href="http://act.yapc.eu/gpw2017">19. Deutscher Perl-Workshop 2017 in Hamburg</a></dd>
         </dl>
-        <p>
-            Kurze Beschreibung Workshop 2017
-        </p>
       </section>
 
  

--- a/static/2018.html
+++ b/static/2018.html
@@ -5,12 +5,9 @@
             <dd>04. bis 06. April 2018</dd>
           <dt>Veranstaltungsort</dt>
             <dd>TH Köln, Gummersbach</dd>
-          <dt>Act!</dt>
-            <dd><a href="http://act.yapc.eu/gpw2018">Act! 2018</a></dd>
+          <dt>Information über die Veranstaltung</dt>
+            <dd><a href="http://act.yapc.eu/gpw2018">20. Deutscher Perl-Workshop 2018 in Gummersbach</a></dd>
         </dl>
-        <p>
-            Kurze Beschreibung Workshop 2018
-        </p>
       </section>
 
  

--- a/static/index.html
+++ b/static/index.html
@@ -1,9 +1,30 @@
       <section id="document" class="col-sm-9 col-md-8">
 		<h2> Über den Deutschen Perl-Workshop</h2>
-		<p>  Der Deutsche Perl-Workshop ist eine jährlich in Deutschland
-					stattfindende <strong>Open-Source-Konferenz für jedermann</strong>,
-					organisiert von der Community der Programmiersprache Perl.
-                </p>
+		<p>
+          Der Deutsche Perl-Workshop ist eine seit 1999 jährlich in Deutschland
+		  stattfindende <strong>Open-Source-Konferenz für jedermann</strong>, organisiert von der
+		  Community der Programmiersprache Perl.
+        </p>
+        <p>
+          Die Vorträge werden überwiegend in deutscher Sprache gehalten, Angebote für
+          englischsprachige Vorträge sind aber durchaus erwünscht.
+        </p>
+        <h4>Über Perl</h4>
+		<p>
+          Perl ist eine Familie von Open-Source-Programmiersprachen:
+        </p>
+        <ul>
+          <li>
+            <a href="https://perl.org">Perl 5</a> wird seit 1987 weiterentwickelt, 2018 wurde die
+            Version 5.28 freigegeben.  Perl 5 ist eine der meistgenutzten Programmiersprachen, läuft
+            auf Plattformen vom Handy bis zum Mainframe und bietet mit dem "Comprehensive Perl
+            Archive Network" (<a href="https://www.cpan.org/">CPAN</a>) über 35000 Erweiterungen an.
+          </li>
+          <li>
+            <a href="https://perl6.org/">Perl 6</a> ist eine damit verwandte Sprache, die viele
+            Elemente aktueller Software-Architekturen direkt in die Sprachbeschreibung aufgenommen
+            hat und dafür bewusst auf Kompatibilität mit Perl 5 verzichtet.
+          </li>
       </section>
 
  

--- a/static/sponsoring.html
+++ b/static/sponsoring.html
@@ -1,0 +1,53 @@
+      <section id="document" class="col-sm-9 col-md-8">
+		<h2>Unterstützen Sie die Deutschen Perl-Workshops</h2>
+
+		<p>
+          <a href="https://perl.org">Perl</a> ist eine Open-Source-Programmiersprache und eine der
+          meistgenutzten Sprachen der Welt. Durch den Perl-Workshop möchten wir die Anzahl der
+          qualifizierten Fachkräfte in Deutschland erhöhen. Der Workshop ist eine gemeinnützige
+          Konferenz mit jährlich wechselndem Veranstaltungsort und wird von der Community selbst
+          organisiert.  Sie unterstützen mit Ihrer Spende also direkt mögliche
+          Mitarbeiter. Zahlreiche Perl-Spezialisten tauschen hier ihre Erfahrungen aus, suchen
+          interessante Herausforderungen und besprechen Neuerungen in der Perl-Welt. Die meisten
+          machen dies aus eigenem Antrieb und auf eigene Kosten.
+        </p>
+
+        <p>
+          Jede finanzielle Unterstützung hilft dabei, den Teilnehmern einen besseren Workshop zu
+          bieten.
+        </p>
+
+        <p>Kontaktadresse für Sponsoren: <a href="mailto:sponsoring@german-perl-workshop.de" class="email icon-envelope">mailto:sponsoring@german-perl-workshop.de</a>
+
+        <p>
+          Die verfügbaren Sponsorenpakete können von Jahr zu Jahr je nach den Gegebenheiten
+          variieren. Hier eine Auswahl:
+        </p>
+
+        <ul>
+          <li>
+            Kurzbeschreibung des Unternehmens / der Organisation auf der Webseite des Workshops
+          </li>
+          <li>Anzeige im gedruckten Programmheft</li>
+          <li>Aufsteller im Vortragsraum</li>
+          <li>Logo auf dem Konferenz-T-Shirt</li>
+          <li>Stand im Vorraum (je nach räumlichen Gegebenheiten begrenzt verfügbar)</li>
+          <li>Einblendung des Logo vor den veröffentlichten Videos</li>
+        </ul>
+
+        <p>Beispiele für individuelle Optionen, die ganz oder teilweise gesponsort bzw. arrangiert werden können:</p>
+
+        <ul>
+          <li>Pre Konferenz Meeting</li>
+          <li>Sponsor a Speaker, tragen sie dazu bei einen (internationalen) &quot;Top&quot; Speaker zum Workshop zu bringen</li>
+          <li>Das Social Event (gemeinsames Abendessen)</li>
+          <li>Catering (Kaffeepausen, Snacks, Mittagessen)</li>
+          <li>Platz für Informationsmaterial (zum Beispiel für einen "Büchertisch")</li>
+          <li>vom Sponsor gestellte Schl&uuml;sselb&auml;nder f&uuml;r die Befestigung der Teilnehmer-Namensschilder</li>
+          <li>vom Sponsor gestellte Konferenztaschen</li>
+          <li>vom Sponsor gestellte Goodies f&uuml;r die Konferenztaschen (Schreibblock, Stift, ...)</li>
+          <li>ein Hackathon (zu einem bestimmten Thema) vor oder nach der Konferenz</li>
+          <li>...und auch anderes, nach Vereinbarung!</li>
+        </ul>
+            
+      </section>

--- a/static/sponsors.html
+++ b/static/sponsors.html
@@ -1,0 +1,9 @@
+      <section id="document" class="col-sm-9 col-md-8">
+		<h2>Die Sponsoren</h2>
+		<p>
+          Die Sponsoren der einzelnen Workshops werden auf den Bereichen der jeweiligen
+          Veranstaltungen, die Sie im Archiv finden, genannt.
+        </p>
+      </section>
+
+ 

--- a/templates/index.html.ep
+++ b/templates/index.html.ep
@@ -44,7 +44,7 @@
       	<div class="elemWrapper">
 
 
-          <nav id="navtop" class="navbar navbar-default navbar-inverse gpw navbar-fixed-topx navbar-static-top bootstrap hiddenx" role="navigation"> <div class="container-fluid"> <div class="navbar-header clearfixafter"> <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#gpwNavbar"> <span class="sr-only">Navigation ein-/ausschalten</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button> <a class="navbar-brand hidden-xs hidden-sm hidden-md hidden-lg" href="index.html" title="Startseite Deutscher Perl-Workshop 2017"> <span class="sitetitle">Deutscher Perl-Workshop</span></div> <div class="collapse navbar-collapse" id="gpwNavbar"> <ul class="nav navbar-nav"> <li class="hidden-smx hidden-md hidden-lg activex start first lv1"> <a href="/" title="Startseite"> Startseite </a> </li> <li class="workshop lv1"> <a href="/"> Workshop </a> <li class="dropdown sponsoring lv1"> <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);"> <span class="visible-sm-inline-block visible-md-inline-block">Sponsoring</span><span class="hidden-sm hidden-md">Unterstützen/Sponsoren</span> <span class="caret"></span> </a> <ul class="dropdown-menu"> <li><a href="sponsoring.html">Sponsor werden</a></li><!--Unterstützen/Sponsoring--> <li><a href="sponsors.html">Workshop Sponsoren</a></li> </ul> </li> </ul> <ul class="nav navbar-nav navbar-right"> <li class="langchanger lv1"><!--todo:languagechanger link via perl--> <a href="?language=en"><span class="glyphicon glyphicon-flag"></span> EN</a> </li> </ul> </div> </div> </nav>
+          <nav id="navtop" class="navbar navbar-default navbar-inverse gpw navbar-fixed-topx navbar-static-top bootstrap hiddenx" role="navigation"> <div class="container-fluid"> <div class="navbar-header clearfixafter"> <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#gpwNavbar"> <span class="sr-only">Navigation ein-/ausschalten</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span> </button> <a class="navbar-brand hidden-xs hidden-sm hidden-md hidden-lg" href="index.html" title="Startseite Deutscher Perl-Workshop 2017"> <span class="sitetitle">Deutscher Perl-Workshop</span></div> <div class="collapse navbar-collapse" id="gpwNavbar"> <ul class="nav navbar-nav"> <li class="hidden-smx hidden-md hidden-lg activex start first lv1"> <a href="/" title="Startseite"> Startseite </a> </li> <li class="workshop lv1"> <a href="/"> Workshop </a> <li class="dropdown sponsoring lv1"> <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:void(0);"> <span class="visible-sm-inline-block visible-md-inline-block">Sponsoring</span><span class="hidden-sm hidden-md">Unterstützen/Sponsoren</span> <span class="caret"></span> </a> <ul class="dropdown-menu"> <li><a href="sponsoring.html">Sponsor werden</a></li><!--Unterstützen/Sponsoring--> <li><a href="sponsors.html">Workshop Sponsoren</a></li> </ul> </li> </ul> <ul class="nav navbar-nav navbar-right"> <%# <li class="langchanger lv1"><!--todo:languagechanger link via perl--> <a href="?language=en"><span class="glyphicon glyphicon-flag"></span> EN</a> </li> %> </ul> </div> </div> </nav>
 
 
       	</div>
@@ -63,10 +63,10 @@
       <aside id="sidebar" class="col-sm-3 col-md-4">
 
         <section id="archivnav" class="elemWrapper archivWrapper">
-          <h2>gpw-Archiv</h2>  
+          <h2>Archiv</h2>  
           <form id="archiv_form" action="#">  
             <fieldset class="form-group"><!--style="display: inline-block;float: right;"-->
-              <label for="archiv">Workshop:</label>    
+              <label for="archiv">Jahr auswählen</label>    
               <select class="selectpicker form-control" id="archiv"><!--style="display: inline-block;width: auto;"-->
               <option value="">-</option>
               <% for my $year ( all_years() ) { %>


### PR DESCRIPTION
Hallo FrankfurtPM,

hier meine Vorschläge zur Anreicherung der Homepage zu den Deutschen Perl-Workshops.
In Kürze:

- Die Seiten "sponsoring.html" und "sponsors.html" haben nun Inhalt, anstatt JSON-Erfolge zu vermelden.
- Auf der Einstiegsseite steht ein kurzer Text "was ist Perl überhaupt".
- Die nur in Orga-Zirkeln bekannten Begriffe "gpw" und "Act!" habe ich ersetzt (für die letzten 5 Jahre).
- Die Sprachumschaltung habe ich, da inhaltlich nicht existent, im Template auskommentiert.

Ich kann auf Wunsch noch das Eliminieren von Warnings und eine andere Behandlung von "not found" liefern, aber das gehört nicht zu den Seiten-Inhalten.