### PR TITLE
Perl5 mit aktueller Jahreszahl, nicht 1987 vorstellen

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -34,10 +34,10 @@
         </p>
         <ul>
           <li>
-            <a href="https://perl.org">Perl 5</a> wird seit 1987 weiterentwickelt, im Juni 2021 wurde die
-            Version 5.34 freigegeben.  Perl 5 ist eine der meistgenutzten Programmiersprachen, läuft
+            Version 5.34 von <a href="https://perl.org">Perl 5</a> wurde im Juni 2021 freigegeben.
+            Perl 5 ist eine der meistgenutzten Programmiersprachen, läuft
             auf Plattformen vom Handy bis zum Mainframe und bietet mit dem "Comprehensive Perl
-            Archive Network" (<a href="https://www.cpan.org/">CPAN</a>) über 35000 Erweiterungen an.
+            Archive Network" (<a href="https://www.cpan.org/">CPAN</a>) über 40&nbsp;000 Erweiterungen an.
           </li>
           <li>
             <a href="https://raku.org/">Raku</a> (früher Perl 6) ist eine damit verwandte Sprache, die viele


### PR DESCRIPTION
Außerdem: Anzahl CPAN-Dists heute bei 42 992.